### PR TITLE
Add script to run scrapers and export data

### DIFF
--- a/scripts/run_scrapers_and_export.R
+++ b/scripts/run_scrapers_and_export.R
@@ -197,7 +197,7 @@ while (attempt <= global_max_attempts) {
       quit(status = 2)
     } else {
       append_log(glue('{format(Sys.time(), tz="UTC")}: RETRYING {runid}'))
-      Sys.sleep(2^attempt)
+      Sys.sleep(2^(attempt-1))
     }
   }
 }


### PR DESCRIPTION
This script runs multiple scrapers to gather data on vendors and GPUs, normalizes the data, and performs completeness checks before logging the results. Closes #1 